### PR TITLE
Add Dockerfile for FastAPI application deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# 5. Expose FastAPI default port
+EXPOSE 8000
+
+# 6. Start FastAPI app with uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
- Created a Dockerfile to containerize the FastAPI application.
- Set up the working directory, copied requirements, and installed dependencies.
- Configured the container to expose port 8000 and start the FastAPI app with Uvicorn.